### PR TITLE
[Feat] #15 CakeColorView UI 구현

### DIFF
--- a/Cakey/Views/CakeyOrderForm/CakeColorView.swift
+++ b/Cakey/Views/CakeyOrderForm/CakeColorView.swift
@@ -8,11 +8,51 @@
 import SwiftUI
 
 struct CakeColorView: View {
+    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
     let value: Int
     @Binding var path: [Int]
+    @State private var selectedColor: Color = .pickerWhite
+    @State private var pickerColor: Color = .white
     
     var body: some View {
-        Text("케이크 색상 선택 뷰 입니다.")
+        ZStack {
+            Color.cakeyYellow1
+                .ignoresSafeArea(.all)
+            
+            
+            ProgressBarCell(currentStep: 1)
+            
+            VStack(spacing: 0) {
+                NoticeCelll(notice1: "어떤 색상을 원하세요?", notice2: "원하는 케이크 색상을 선택해 주세요")
+                    .padding(.bottom, 30)
+                
+                // TODO: 람지의 3D케이크 자리
+                Rectangle()
+                    .fill(selectedColor)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .padding(.horizontal, 20)
+                    .padding(.bottom, 50)
+                
+                ColorPickerCell(selectedColor: $selectedColor, pickerColor: $pickerColor)
+                    .padding(.bottom, 70)
+                
+                NextButtonCell(nextValue: { path.append(3)} )
+            }
+            .padding(.top, 86)
+            .padding(.bottom, 20)
+        }
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button {
+                    presentationMode.wrappedValue.dismiss()
+                } label: {
+                    Image(systemName: "chevron.backward")
+                        .font(.cakeyCallout)
+                        .foregroundStyle(.cakeyOrange1)
+                }
+            }
+        }
     }
 }
 

--- a/Cakey/Views/CakeyOrderForm/CakeImageView.swift
+++ b/Cakey/Views/CakeyOrderForm/CakeImageView.swift
@@ -1,0 +1,41 @@
+//
+//  CakeImageView.swift
+//  Cakey
+//
+//  Created by Lee Wonsun on 11/7/24.
+//
+
+import SwiftUI
+
+struct CakeImageView: View {
+    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+    let value: Int
+    @Binding var path: [Int]
+    
+    var body: some View {
+        ZStack {
+            Color.cakeyYellow1
+                .ignoresSafeArea(.all)
+            
+            ProgressBarCell(currentStep: 2)
+            
+            Text("케이크 이미지와 키워드 추가하는 뷰 입니다.")
+        }
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button {
+                    presentationMode.wrappedValue.dismiss()
+                } label: {
+                    Image(systemName: "chevron.backward")
+                        .font(.cakeyCallout)
+                        .foregroundStyle(.cakeyOrange1)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    CakeImageView(value: 3, path: .constant([3]))
+}

--- a/Cakey/Views/Components/ColorPickerCell.swift
+++ b/Cakey/Views/Components/ColorPickerCell.swift
@@ -1,0 +1,71 @@
+//
+//  ColorPickerCell.swift
+//  Cakey
+//
+//  Created by Lee Wonsun on 11/7/24.
+//
+
+import SwiftUI
+
+struct ColorPickerCell: View {
+    let colorList: [Color] = [.pickerWhite, .pickerPink, .pickerYellow, .pickerBlue, .pickerPurple]
+    @Binding var selectedColor: Color
+    @Binding var pickerColor: Color
+    @State var selectedColorIndex: Int = 0
+    
+    var body: some View {
+        HStack(spacing: 20) {
+            ForEach(0..<colorList.count, id: \.self) { index in
+                VStack(spacing: 8) {
+                    if selectedColorIndex == index {
+                        Circle()
+                            .fill(.cakeyOrange1)
+                            .frame(width: 8)
+                    } else {
+                        Circle()
+                            .fill(.cakeyOrange1).opacity(0)
+                            .frame(width: 8)
+                    }
+                    
+                    
+                    Circle()
+                        .stroke(.cakeyOrange1, lineWidth:4)
+                        .fill(colorList[index])
+                        .frame(width: 28)
+                        .onTapGesture {
+                            selectedColor = colorList[index]
+                            selectedColorIndex = index
+                        }
+                }
+            }
+            
+            VStack(spacing: 8) {
+                if selectedColorIndex == colorList.count {
+                    Circle()
+                        .fill(.cakeyOrange1)
+                        .frame(width: 8)
+                } else {
+                    Circle()
+                        .fill(.cakeyOrange1).opacity(0)
+                        .frame(width: 8)
+                }
+                
+                ColorPicker("", selection: $pickerColor, supportsOpacity: false)
+                    .labelsHidden()
+                    .onChange(of: pickerColor) { newColor in
+                        selectedColor = newColor
+                        selectedColorIndex = colorList.count
+                    }
+            }
+        }
+    }
+}
+
+#Preview {
+    ZStack {
+        Color.cakeyYellow1
+            .ignoresSafeArea(.all)
+        
+        ColorPickerCell(selectedColor: .constant(.pickerWhite), pickerColor: .constant(.white))
+    }
+}

--- a/Cakey/Views/Components/NextButtonCell.swift
+++ b/Cakey/Views/Components/NextButtonCell.swift
@@ -1,0 +1,37 @@
+//
+//  NextButtonCell.swift
+//  Cakey
+//
+//  Created by Lee Wonsun on 11/7/24.
+//
+
+import SwiftUI
+
+struct NextButtonCell: View {
+    var nextValue: () -> Void
+    
+    var body: some View {
+        Button {
+            nextValue()
+        } label: {
+            Text("다음")
+                .customStyledFont(font: .cakeyBody, color: .cakeyYellow1)
+                .padding(.vertical, 13)
+                .frame(maxWidth: .infinity)
+                .background {
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(.cakeyOrange1)
+                }
+                .padding(.horizontal, 24)
+        }
+    }
+}
+
+//#Preview {
+//    ZStack {
+//        Color.cakeyYellow1
+//            .ignoresSafeArea(.all)
+//        
+//        NextButtonCell()
+//    }
+//}

--- a/Cakey/Views/Components/NoticeCelll.swift
+++ b/Cakey/Views/Components/NoticeCelll.swift
@@ -1,0 +1,32 @@
+//
+//  NoticeCelll.swift
+//  Cakey
+//
+//  Created by Lee Wonsun on 11/7/24.
+//
+
+import SwiftUI
+
+struct NoticeCelll: View {
+    @State var notice1: String = ""
+    @State var notice2: String = ""
+
+    var body: some View {
+        VStack(spacing: 10) {
+            Text("\(notice1)")
+                .customStyledFont(font: .cakeyHeadline, color: .cakeyOrange1)
+            
+            Text("\(notice2)")
+                .customStyledFont(font: .cakeyCallout, color: .cakeyOrange1)
+        }
+    }
+}
+
+#Preview {
+    ZStack {
+        Color.cakeyYellow1
+            .ignoresSafeArea(.all)
+        
+        NoticeCelll(notice1: "어떤 색상을 원하세요?", notice2: "원하는 케이크 색상을 선택해 주세요")
+    }
+}

--- a/Cakey/Views/Components/ProgressBarCell.swift
+++ b/Cakey/Views/Components/ProgressBarCell.swift
@@ -1,0 +1,42 @@
+//
+//  ProgressBarCell.swift
+//  Cakey
+//
+//  Created by Lee Wonsun on 11/7/24.
+//
+
+import SwiftUI
+
+struct ProgressBarCell: View {
+    @State var currentStep: Int = 0
+    
+    var body: some View {
+        VStack {
+            ZStack {
+                Rectangle()
+                    .fill(.cakeyOrange1).opacity(0.3)
+                    .frame(maxWidth: .infinity, maxHeight: 4)
+                
+                HStack(spacing: 0) {
+                    ForEach(0..<4) { step in
+                        Rectangle()
+                            .fill(step < currentStep ? .cakeyOrange1 : .cakeyOrange1.opacity(0))
+                            .frame(maxWidth: .infinity, maxHeight: 4)
+                    }
+                }
+            }
+            
+            Spacer()
+        }
+        .padding(.top, 2)
+    }
+}
+
+#Preview {
+    ZStack {
+        Color.cakeyYellow1
+            .ignoresSafeArea(.all)
+        
+        ProgressBarCell()
+    }
+}

--- a/Cakey/Views/Home/HomeView.swift
+++ b/Cakey/Views/Home/HomeView.swift
@@ -68,6 +68,8 @@ struct HomeView: View {
                         ArchieveView()
                     } else if value == 2 {
                         CakeColorView(value: value, path: $path)
+                    } else if value == 3 {
+                        CakeImageView(value: value, path: $path)
                     }
                 }
                 


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
CakeColorView UI 1차 구현

<!-- Close #15  -->

## 작업 내용
### 1. 프로그래스 바 cell 작업
- ForEach문으로 총 4개로 분리해서 hstack으로 현황 나타내도록 함
- 해당 뷰에서 value 몇단계인지 인식해서 값 전달!

### 2. 안내 문구 cell 작업
- 같은 위치에 같은 폰트/크기/색상으로 4개의 단계에서 다 사용되기 때문에 cell 작업 진행함
- 기본 값은 "" 공백으로 두고, 해당 뷰에서 필요한 텍스트 입력

### 3. 컬러피커 cell 작업
- 마찬가지로 레터링 단계에서 필요하기 때문에 cell로 구분해서 작업
- 디폴트 색상은 ForEach문으로 두고, 그 다음 ColorPicker 둠
- 같은 대상으로 색을 바꿔야해서, ColorPicker는 onChange를 사용해 디폴트 색상이 받는 색에 연동시킴
- 현재 선택한 색상 위에 동그라미 표시가 있는데, 이는 인덱스 넘버를 이용해 if문으로 조건에 따라 보이도록 구현

### 4. 다음 버튼 cell 작업
- 다음 버튼은 반응형으로만 잘 작동하도록 하여 UI 구현
- 버튼의 action 부분은 클로저로 두어, 호출하는 뷰에서 value값을 path에 추가 및 전달

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->
<img width="243" alt="image" src="https://github.com/user-attachments/assets/ba7d4d28-287a-4608-8978-dd3b3bffa275">



### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
