### PR TITLE
[Chore] #23 CakeColorView 컬러피커 투명도 조절 가능하도록 수정

### DIFF
--- a/Cakey/Views/Components/ColorPickerCell.swift
+++ b/Cakey/Views/Components/ColorPickerCell.swift
@@ -50,9 +50,9 @@ struct ColorPickerCell: View {
                         .frame(width: 8)
                 }
                 
-                ColorPicker("", selection: $pickerColor, supportsOpacity: false)
+                ColorPicker("", selection: $pickerColor)
                     .labelsHidden()
-                    .onChange(of: pickerColor) { newColor in
+                    .onChange(of: pickerColor, initial: false) { newColor, oldColor in
                         selectedColor = newColor
                         selectedColorIndex = colorList.count
                     }


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
CakeColorView 컬러피커 투명도 조절 가능하도록 수정
<!-- Close #23  -->

## 작업 내용
### 1. ColorPicker 투명도 조절 기능 수정
- ColorPicker("", selection: picker, supports opacity : true) : true를 false로 수정

### 2. .onChange 방식 변경
- 기존 사용 방식은 deprecated 되는 사용법이라 iOS17 이후 방식으로 교체
- .onChange(of: perform:) <기존 방식> => .onChange(of: initial:) + 2개의 value받아야함 
- newValue, oldValue를 in으로 받지만 둘 다 무조건적으로 사용해야하는 것은 아님
- 케이키의 경우 newValue값만으로 활용

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->
<img width="242" alt="image" src="https://github.com/user-attachments/assets/69ca0709-082a-4e81-86b4-aff61a619471">

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
