### PR TITLE
[Feat] #28 CakeImageView 안내문구, SKIP버튼, 다음버튼 추가(기능은 미구현)

### DIFF
--- a/Cakey/Views/CakeyOrderForm/CakeDecorationView.swift
+++ b/Cakey/Views/CakeyOrderForm/CakeDecorationView.swift
@@ -1,0 +1,28 @@
+//
+//  CakeDecorationView.swift
+//  Cakey
+//
+//  Created by Lee Wonsun on 11/9/24.
+//
+
+import SwiftUI
+
+struct CakeDecorationView: View {
+    let value: Int
+    @Binding var path: [Int]
+    
+    var body: some View {
+        ZStack {
+            Color.cakeyYellow1
+                .ignoresSafeArea(.all)
+            
+            ProgressBarCell(currentStep: 3)
+            
+            Text("3D 케이크에 요소 배치하는 화면입니다.")
+        }
+    }
+}
+
+#Preview {
+    CakeDecorationView(value: 4, path: .constant([4]))
+}

--- a/Cakey/Views/CakeyOrderForm/CakeImageView.swift
+++ b/Cakey/Views/CakeyOrderForm/CakeImageView.swift
@@ -11,6 +11,7 @@ struct CakeImageView: View {
     @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
     let value: Int
     @Binding var path: [Int]
+    @State private var keyboardHeight: CGFloat = 0
     
     var body: some View {
         ZStack {
@@ -24,6 +25,10 @@ struct CakeImageView: View {
                     .padding(.bottom, 54)
                 
                 DecoCarouselCell()
+                    .padding(.bottom, 60)
+                
+                textFieldCell()
+                    .padding(.bottom, keyboardHeight - 200)
                 
                 Spacer()
                 
@@ -42,6 +47,7 @@ struct CakeImageView: View {
                         .font(.cakeyCallout)
                         .foregroundStyle(.cakeyOrange1)
                 }
+                .padding(.bottom, keyboardHeight)
             }
             
             ToolbarItem(placement: .topBarTrailing) {
@@ -51,8 +57,29 @@ struct CakeImageView: View {
                     Text("SKIP")
                         .customStyledFont(font: .cakeyCallout, color: .cakeyOrange1)
                 }
+                .padding(.bottom, keyboardHeight)
 
             }
+        }
+        .onAppear {
+            // 키보드 높이 감지
+            NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillShowNotification, object: nil, queue: .main) { notification in
+                if let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
+                    withAnimation {
+                        self.keyboardHeight = keyboardFrame.height
+                    }
+                }
+            }
+            NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillHideNotification, object: nil, queue: .main) { _ in
+                withAnimation {
+                    self.keyboardHeight = 0
+                }
+            }
+        }
+        .onDisappear {
+            // 옵저버 제거
+            NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
+            NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
         }
     }
 }

--- a/Cakey/Views/CakeyOrderForm/CakeImageView.swift
+++ b/Cakey/Views/CakeyOrderForm/CakeImageView.swift
@@ -19,11 +19,18 @@ struct CakeImageView: View {
             
             ProgressBarCell(currentStep: 2)
             
-            VStack {
+            VStack(spacing: 0) {
                 NoticeCelll(notice1: "원하는 데코가 있나요?", notice2: "최대  6개까지 추가할 수 있어요")
+                    .padding(.bottom, 54)
+                
+                DecoCarouselCell()
+                
+                Spacer()
                 
                 NextButtonCell(nextValue: {path.append(4)})
             }
+            .padding(.top, 86)
+            .padding(.bottom, 20)
         }
         .navigationBarBackButtonHidden(true)
         .toolbar {

--- a/Cakey/Views/CakeyOrderForm/CakeImageView.swift
+++ b/Cakey/Views/CakeyOrderForm/CakeImageView.swift
@@ -19,7 +19,11 @@ struct CakeImageView: View {
             
             ProgressBarCell(currentStep: 2)
             
-            Text("케이크 이미지와 키워드 추가하는 뷰 입니다.")
+            VStack {
+                NoticeCelll(notice1: "원하는 데코가 있나요?", notice2: "최대  6개까지 추가할 수 있어요")
+                
+                NextButtonCell(nextValue: {path.append(4)})
+            }
         }
         .navigationBarBackButtonHidden(true)
         .toolbar {
@@ -31,6 +35,16 @@ struct CakeImageView: View {
                         .font(.cakeyCallout)
                         .foregroundStyle(.cakeyOrange1)
                 }
+            }
+            
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    // TODO: 스킵 기능 구현 필요
+                } label: {
+                    Text("SKIP")
+                        .customStyledFont(font: .cakeyCallout, color: .cakeyOrange1)
+                }
+
             }
         }
     }

--- a/Cakey/Views/Components/DecoCarouselCell.swift
+++ b/Cakey/Views/Components/DecoCarouselCell.swift
@@ -1,0 +1,86 @@
+//
+//  DecoCarouselCell.swift
+//  Cakey
+//
+//  Created by Lee Wonsun on 11/9/24.
+//
+
+import SwiftUI
+
+struct DecoCarouselCell: View {
+    @State private var currentIndex: Int = 0
+    
+    var body: some View {
+        VStack(spacing: 40) {
+            // MARK: 캐러샐 가로 스크롤 뷰
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHStack(spacing: 20) {
+                    ForEach(0..<6) { index in
+                        GeometryReader { geo in
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(.cakeyOrange2)
+                            .frame(width: 230, height: 230)
+                            .overlay {
+                                VStack(spacing: 20) {
+                                    Image(systemName: "plus.circle.fill")
+                                        .font(.symbolLargeTitle)
+                                    
+                                    HStack(spacing: 5) {
+                                        Image(systemName: "photo")
+                                        Text("이미지 추가")
+                                    }
+                                    .font(.cakeySubhead)
+                                }
+                                .foregroundStyle(.cakeyOrange3)
+                            }
+                            .scrollTransition(.interactive, axis: .horizontal) { effect, phase in
+                                effect
+                                    .scaleEffect(phase.isIdentity ? 1 : 0.9)
+                            }
+                            .onAppear {
+                                updateCurrentIndex(for: geo, index: index)
+                            }
+                            .onChange(of: geo.frame(in: .global).minX, initial: true) { _, _ in
+                                updateCurrentIndex(for: geo, index: index)
+                            }
+                        }
+                        .frame(width: 230, height: 230) // geometry로 인해 무너지는 프레임 재설정
+                    }
+                }
+                .padding(.leading, (UIScreen.main.bounds.width - 230) / 2)
+                .scrollTargetLayout()
+            }
+            .scrollTargetBehavior(.viewAligned)
+            .frame(height: 230)
+            
+            // MARK: 캐러샐 indicators
+            HStack(spacing: 8) {
+                ForEach(0..<6) { index in
+                    Circle()
+                        .fill(currentIndex == index ? .cakeyOrange1 : .cakeyOrange2)
+                        .frame(width: 8)
+                }
+            }
+        }
+    }
+    
+    // 캐러셀 옆으로 넘어갔을 때 감지해주는 함수
+    private func updateCurrentIndex(for geo: GeometryProxy, index: Int) {
+        let screenWidth = UIScreen.main.bounds.width
+        let position = geo.frame(in: .global).midX
+        
+        // 현재 화면 중앙과 뷰의 위치를 비교하여 가까운 경우 업데이트
+        if abs(position - screenWidth / 2) < 115 {
+            currentIndex = index
+        }
+    }
+}
+
+#Preview {
+    ZStack {
+        Color.cakeyYellow1
+            .ignoresSafeArea(.all)
+        
+        DecoCarouselCell()
+    }
+}

--- a/Cakey/Views/Components/DecoCarouselCell.swift
+++ b/Cakey/Views/Components/DecoCarouselCell.swift
@@ -47,7 +47,7 @@ struct DecoCarouselCell: View {
                         .frame(width: 230, height: 230) // geometry로 인해 무너지는 프레임 재설정
                     }
                 }
-                .padding(.leading, (UIScreen.main.bounds.width - 230) / 2)
+                .padding(.horizontal, (UIScreen.main.bounds.width - 230) / 2)
                 .scrollTargetLayout()
             }
             .scrollTargetBehavior(.viewAligned)

--- a/Cakey/Views/Components/textFieldCell.swift
+++ b/Cakey/Views/Components/textFieldCell.swift
@@ -1,0 +1,46 @@
+//
+//  textFieldCell.swift
+//  Cakey
+//
+//  Created by Lee Wonsun on 11/9/24.
+//
+
+import SwiftUI
+
+struct textFieldCell: View {
+    @State private var text: String = ""
+    
+    var body: some View {
+        VStack(alignment: .trailing, spacing: 6) {
+            // MARK: 텍스트 필드
+            TextField("예시) 감자를 닮은 햄스터", text: $text)
+                .padding(.leading, 14)
+                .padding(.vertical, 16.5)
+                .background(Color.white)
+                .frame(width: 292)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(.cakeyOrange1, lineWidth: 3)
+                )
+                .onChange(of: text, initial: true) { oldValue, newValue in
+                    if newValue.count > 15 {
+                        text = String(newValue.prefix(15))
+                    }
+                }
+            
+            // MARK: 글자 제한 수 카운트
+            Text("\(text.count)/15")
+                .customStyledFont(font: .cakeyCaption1, color: .cakeyOrange1)
+        }
+    }
+}
+
+#Preview {
+    ZStack {
+        Color.cakeyYellow1
+            .ignoresSafeArea(.all)
+        
+        textFieldCell()
+    }
+}

--- a/Cakey/Views/Home/HomeView.swift
+++ b/Cakey/Views/Home/HomeView.swift
@@ -70,6 +70,8 @@ struct HomeView: View {
                         CakeColorView(value: value, path: $path)
                     } else if value == 3 {
                         CakeImageView(value: value, path: $path)
+                    } else if value == 4 {
+                        CakeDecorationView(value: value, path: $path)
                     }
                 }
                 


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
CakeImageView UI 구현
- [x] 안내 문구 추가
- [x] SKIP버튼 추가
- [x] 다음버튼 추가
- [x] 이미지 추가하는 carousel 구현 (앨범 및 이미지 추가 로직은 미구현 상태)
- [x] 텍스트 필드 구현 (사진 추가하면 나타나는 로직 기능은 미구현으로 & 키보드 올라오면 화면도 같이 올라가도록 해야함)

<!-- Close #28  -->

## 작업 내용
### 1. 안내 문구 추가
- 만들어 뒀던 noticeCell 활용하여 추가

### 2. SKIP 버튼 추가
- ToolbarItem 활용하여 버튼으로 추가 (action 부분 기능은 미구현)

### 3. 다음 버튼 추가
- 만들어 뒀던 nextButtonCell 활용하여 추가
- 다음으로 넘어갈 임의의 CakeDecorationView 만들어서 연결해둠
- HomeView에서 value == 4일 때 decoration 화면으로 연결되도록 코드 추가

### 4. CarouselCell 구현
- iOS17 이상에서 사용 가능한 캐러샐 관련 코드 사용
- scrollTransition : 현재 보이는 영역 외는 크기 0.9 배율로 설정하는 작업
- scrollTargetLayout() : 현재 보이는 타겟 기준으로 작동하도록 설정
- scrollTargetBehavior : 슬라이드 했을 때, 화면에 딱 맞게 고정되도록 하는 작업
- 캐러샐 indicator과 index를 일치시켜서 indicator 기능을 구현하려고 했으나, 따로 tapGesture나 onChange만으로 인식할 수 있는 방법이 없었음 -> geometryReader 활용하여 현재 화면 중앙에서 rectangle의 사이즈 절반 만큼 벗어나면 자동으로 이동한 것으로 인식시켜서 index에 변화를 줌
- 그래서 캐러샐에서의 index == indecator's index 이면 색상 변화를 주는 삼항연산자 사용하여 indicator 구현

📌 아직 앨범 기능이나, 선택했을 때 달라지는 외양은 미구현 상태

### 5. textField 구현
- 글자 수 prefix(15) 모디파이어 활용하여 제한
- text.count 활용하여 실시간 글자 수 체크 가능하도록 함
- 텍스트필드가 키보드에 가려지는 이슈는... UIKit 코드 도움으로 해결했으나 아직 UIKit 하수라 이해도 낮음...ㅎㅎ...

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->
<img width="275" alt="image" src="https://github.com/user-attachments/assets/9f59f7a6-78b0-4e3f-9aa8-89743a04cf89">


### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
