### PR TITLE
[Fix] #33 ColorPickerCell 코드 수정

### DIFF
--- a/Cakey/Views/CakeyOrderForm/CakeColorView.swift
+++ b/Cakey/Views/CakeyOrderForm/CakeColorView.swift
@@ -13,6 +13,7 @@ struct CakeColorView: View {
     @Binding var path: [Int]
     @State private var selectedColor: Color = .pickerWhite
     @State private var pickerColor: Color = .white
+    @State private var selectedColorIndex: Int = 0
     
     var body: some View {
         ZStack {
@@ -33,7 +34,7 @@ struct CakeColorView: View {
                     .padding(.horizontal, 20)
                     .padding(.bottom, 50)
                 
-                ColorPickerCell(selectedColor: $selectedColor, pickerColor: $pickerColor)
+                ColorPickerCell(selectedColor: $selectedColor, pickerColor: $pickerColor, selectedColorIndex: $selectedColorIndex)
                     .padding(.bottom, 70)
                 
                 NextButtonCell(nextValue: { path.append(3)} )

--- a/Cakey/Views/Components/ColorPickerCell.swift
+++ b/Cakey/Views/Components/ColorPickerCell.swift
@@ -11,7 +11,7 @@ struct ColorPickerCell: View {
     let colorList: [Color] = [.pickerWhite, .pickerPink, .pickerYellow, .pickerBlue, .pickerPurple]
     @Binding var selectedColor: Color
     @Binding var pickerColor: Color
-    @State var selectedColorIndex: Int = 0
+    @Binding var selectedColorIndex: Int
     
     var body: some View {
         HStack(spacing: 20) {
@@ -52,7 +52,7 @@ struct ColorPickerCell: View {
                 
                 ColorPicker("", selection: $pickerColor)
                     .labelsHidden()
-                    .onChange(of: pickerColor, initial: false) { newColor, oldColor in
+                    .onChange(of: pickerColor, initial: false) { oldColor, newColor in
                         selectedColor = newColor
                         selectedColorIndex = colorList.count
                     }
@@ -66,6 +66,6 @@ struct ColorPickerCell: View {
         Color.cakeyYellow1
             .ignoresSafeArea(.all)
         
-        ColorPickerCell(selectedColor: .constant(.pickerWhite), pickerColor: .constant(.white))
+        ColorPickerCell(selectedColor: .constant(.pickerWhite), pickerColor: .constant(.white), selectedColorIndex: .constant(0))
     }
 }


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
컬러피커로 색상 선택 시 짝수 번째에서 색상 변경 일어나지 않는 현상 수정
<!-- Close #33  -->

## 작업 내용
### 1. ColorPickerCell 내 컬러피커 부분 코드 수정
- onChange에서 oldColor, newColor 순서를 바꿔서 테스트 진행해보니 정상적으로 작동되어 그 부분 수정
- selectedColorIndex가 디폴트로 .pickerWhite 색상에 있도록 하기 위해 변수 선언 일부 수정

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
