### PR TITLE
[Feat] #19 Realm 설치 및 manager 생성, 모델 구조 수정 후 viewModel 생성

### DIFF
--- a/Cakey/CakeyApp.swift
+++ b/Cakey/CakeyApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct CakeyApp: App {
     var body: some Scene {
         WindowGroup {
-            HomeView()
+            ContentView()
         }
     }
 }

--- a/Cakey/ContentView.swift
+++ b/Cakey/ContentView.swift
@@ -7,16 +7,60 @@
 
 import SwiftUI
 
+//var id: String = UUID().uuidString
+//var cakeColor: String?
+//var letteringText: String?
+//var letteringColor: String?
+//var cakeImages: [decoElements] = []
+//var saveDate: Date = .now
+//var isComplete: Bool = false
+
 struct ContentView: View {
+    @State var cakeyViewModel = CakeyViewModel(cakeyModel: CakeyModel())
+    
     var body: some View {
-        VStack {
-            Text("Cakey")
+        ZStack {
+            VStack {
+                if let cakey = cakeyViewModel.readSortedCakeys().first {
+                    Text("\(cakey.cakeColor ?? "")")
+                    Text("\(cakey.letteringText ?? "")")
+                    Text("\(cakey.letteringColor ?? "")")
+                    Text("\(cakey.saveDate)")
+                    Text("\(cakey.isComplete)")
+                }
+                
+                Text("\(cakeyViewModel.readSortedCakeys()[1].cakeColor ?? "")")
+                Text("\(cakeyViewModel.readSortedCakeys()[1].letteringText ?? "")")
+                Text("\(cakeyViewModel.readSortedCakeys()[1].letteringColor ?? "")")
+                Text("\(cakeyViewModel.readSortedCakeys()[1].saveDate)")
+                Text("\(cakeyViewModel.readSortedCakeys()[1].isComplete)")
+                
+                Button {
+                    cakeyViewModel.cakeyModel.cakeColor = "짜몽"
+                    cakeyViewModel.cakeyModel.letteringText = "원선"
+                    cakeyViewModel.cakeyModel.letteringColor = "기영"
+                    cakeyViewModel.cakeyModel.saveDate = .now
+                    cakeyViewModel.cakeyModel.isComplete = false
+                    cakeyViewModel.updateCakey()
+                    cakeyViewModel.readSortedCakeys()
+                } label: {
+                    Text("cakeyColor")
+                }
+                
+                Button {
+                    cakeyViewModel.deleteCakey(key: cakeyViewModel.readSortedCakeys()[1].id)
+                } label: {
+                    Text("삭제")
+                }
+
+
+            }
                 
         }
         .padding()
     }
 }
 
-#Preview {
-    ContentView()
-}
+//#Preview {
+//    ContentView()
+//}

--- a/Cakey/Model/CakeyModel.swift
+++ b/Cakey/Model/CakeyModel.swift
@@ -6,15 +6,63 @@
 //
 
 import Foundation
+import RealmSwift
 
 struct CakeyModel {
+    var id: String = UUID().uuidString
     var cakeColor: String?
     var letteringText: String?
     var letteringColor: String?
     var cakeImages: [decoElements] = []
+    var saveDate: Date = .now
+    var isComplete: Bool = false
 }
 
-struct decoElements {
+struct decoElements: Decodable, Encodable {
     var image: Data
     var description: String
 }
+
+extension CakeyModel: Persistable {
+    typealias PersistedObject = CakeyEntity
+    
+    init(persistedObject: CakeyEntity) {
+        let decoder = JSONDecoder()
+        
+        self.id = persistedObject.id
+        self.cakeColor = persistedObject.cakeColor
+        self.letteringText = persistedObject.letteringText
+        self.letteringColor = persistedObject.letteringColor
+        self.cakeImages = try! decoder.decode([decoElements].self, from: persistedObject.cakeImages!)
+        self.saveDate = persistedObject.saveDate
+        self.isComplete = persistedObject.isCompleted
+    }
+    
+    func persistedObject() -> CakeyEntity {
+        let encoder = JSONEncoder()
+        let cakey = CakeyEntity()
+        
+        cakey.id = self.id
+        cakey.cakeColor = self.cakeColor
+        cakey.letteringText = self.letteringText
+        cakey.letteringColor = self.letteringColor
+        cakey.cakeImages = try! encoder.encode(self.cakeImages)
+        cakey.saveDate = self.saveDate
+        cakey.isCompleted = self.isComplete
+        
+        return cakey
+    }
+}
+
+
+class CakeyEntity: Object {
+    @Persisted(primaryKey: true) var id: String
+    @Persisted var cakeColor: String?
+    @Persisted var letteringText: String?
+    @Persisted var letteringColor: String?
+    @Persisted var cakeImages: Data?
+    @Persisted var saveDate: Date
+    @Persisted var isCompleted: Bool
+}
+
+

--- a/Cakey/Model/CakeyViewModel.swift
+++ b/Cakey/Model/CakeyViewModel.swift
@@ -1,0 +1,38 @@
+//
+//  CakeyViewModel.swift
+//  Cakey
+//
+//  Created by Lee Wonsun on 11/10/24.
+//
+
+import Foundation
+import SwiftUI
+
+
+@Observable
+class CakeyViewModel {
+    
+    @ObservationIgnored let realm = RealmManager.shared
+    
+    var cakeyModel: CakeyModel
+    
+    init(cakeyModel: CakeyModel) {
+        self.cakeyModel = cakeyModel
+        self.realm.addCakey(cakeyModel)  // Create
+    }
+    
+    // Read
+    func readSortedCakeys() -> [CakeyModel] {
+        self.realm.readCakey().sorted(by: {$0.saveDate > $1.saveDate} )
+    }
+    
+    // Update
+    func updateCakey() {
+        self.realm.updateCakey(self.cakeyModel)
+    }
+    
+    // Delete
+    func deleteCakey(key: String) {
+        self.realm.deleteCakey(key)
+    }
+}

--- a/Cakey/Model/Manager/RealmManager.swift
+++ b/Cakey/Model/Manager/RealmManager.swift
@@ -1,0 +1,62 @@
+//
+//  RealmManager.swift
+//  Cakey
+//
+//  Created by Lee Wonsun on 11/10/24.
+//
+
+import Foundation
+import SwiftUI
+import RealmSwift
+
+class RealmManager {
+    
+    static let shared = RealmManager()
+    
+    private init() {}
+    
+    let realm = try! Realm()
+    
+    // Create
+    func addCakey(_ cakeyModel: CakeyModel) {
+        //log 출력
+        print(#fileID, #function, #line, "경로: \(Realm.Configuration.defaultConfiguration.fileURL!)")
+        
+        let cakey = cakeyModel.persistedObject()
+        
+        try! realm.write {
+            realm.add(cakey)
+        }
+    }
+    
+    // Read
+    func readCakey() -> [CakeyModel] {
+        
+        let cakeys = realm.objects(CakeyEntity.self)
+        
+        return cakeys.map{ CakeyModel(persistedObject: $0) }
+    }
+    
+    // Update
+    func updateCakey(_ cakeyModel: CakeyModel) {
+        
+        let cakey = cakeyModel.persistedObject()
+        let updateCakey = realm.object(ofType: CakeyEntity.self, forPrimaryKey: cakey.id)
+        
+        try! realm.write {
+            realm.add(cakey, update: .modified)
+        }
+    }
+    
+    // Delete
+    func deleteCakey(_ key: String) {
+        
+        guard let object = realm.object(ofType: CakeyEntity.self, forPrimaryKey: key) else { return }        
+        
+        try! realm.write {
+            realm.delete(object)
+        }
+    }
+}
+
+

--- a/Cakey/Model/Protocol/Persistable.swift
+++ b/Cakey/Model/Protocol/Persistable.swift
@@ -1,0 +1,14 @@
+//
+//  Persistable.swift
+//  Cakey
+//
+//  Created by Lee Wonsun on 11/10/24.
+//
+
+import RealmSwift
+
+public protocol Persistable {
+    associatedtype PersistedObject: RealmSwift.Object
+    init(persistedObject: PersistedObject)
+    func persistedObject() -> PersistedObject
+}

--- a/CakeyTests/CakeyTests.swift
+++ b/CakeyTests/CakeyTests.swift
@@ -1,0 +1,35 @@
+//
+//  CakeyTests.swift
+//  CakeyTests
+//
+//  Created by Lee Wonsun on 11/11/24.
+//
+
+import XCTest
+
+final class CakeyTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
데이터 저장을 위해 Realm SPM 설치 후 연결 작업 진행
<!-- Close #19  -->

## 작업 내용
### 1. Realm SPM 설치
- 패키지 매니저 설치
- 설치 후 preview 오류 남 -> 클린 빌드 하니까 해결!

### 2. CakeyModel 수정
- 렐름 사용해 데이터를 저장할 때 구조체를 그냥 저장하면 이슈가 있다고 함 (구글링 통해)
- 뷰에서 사용할 구조체 CakeyModel을 두고, 데이터를 저장할 클래스 CakeyEntity를 생성
- CakeyEntity에는 Object를 채택한 후 @Persisted 프로퍼티를 사용해 변수 선언해야 함
- 그리고 구조체의 extension으로 CakeyEntitiy를 주입시켜 뷰에서는 구조체로 사용하되, 해당 구조체를 가지고 클래스에 저장할 수 있도록 구현
- 사용자 지정 타입(ex. [decoElements]) 같은 애들은 data 타입으로 저장해서 인코딩 디코딩의 과정을 거쳐야 함

### 3. RealmManager 생성
- 싱글톤 패턴으로 사용할 수 있도록 RealmManager 선언
- 외부에서 사용할 수 없도록 private init으로 생성자 선언
- CRUD에 해당하는 함수 구현 -> 여기서 cakeyModel 관련해서 인자로 받도록 구현

### 4. CakeyViewModel 구현
- 렐름매니저를 싱글톤 패턴으로 선언 -> @ObservationIgnored 프로퍼티 사용해서 @Observable의 영향을 받지 않도록 함
- 렐름 매니저에 있던 CRUD 활용해서 함수 구현
- Read 불러오기의 경우 최신 날짜 순으로 받도록 함

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
... 여긴 코드리뷰에 코멘트를 남기기가 애매해서 나중에 궁금한거 직접 물어봐주세용가리