### PR TITLE
[Chore]] #61 오더폼 뷰에서 탭뷰 제거

### DIFF
--- a/Cakey/Views/CakeyOrderForm/CakeOrderformView.swift
+++ b/Cakey/Views/CakeyOrderForm/CakeOrderformView.swift
@@ -104,13 +104,12 @@ struct CakeOrderformView: View {
         }
     }
     
+    @ViewBuilder
     func cakeImage() -> some View {
-            Rectangle()
-                .fill(.pickerPink)
-                .frame(width: 300, height: 250)
-                .overlay {
-                    Text("1")
-                }
+        Image(.zzamong)
+            .resizable()
+            .scaledToFit()
+            .frame(width: 300, height: 250)
     }
     
     @ViewBuilder
@@ -154,9 +153,10 @@ struct CakeOrderformView: View {
                 Spacer()
             }
             .padding(.leading, 17)
-            .padding(.bottom, -20)
+            .padding(.bottom, 28)
             
             cakeImage()
+                .padding(.bottom, 16)
             
             designKeywordLists()
         }


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
오더폼 뷰에서 탭뷰 제거
<!-- Close #61  -->

## 작업 내용
### 1. 탭뷰 제거
- 탭뷰 제거하면서 임의로 넣어뒀던 rectangle 도형 이미지로 교체
- 각 컴포넌트 간 패딩 조절

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
