### PR TITLE
[Chore] #79 CakeOrderformView 키워드 리스트 UI 구현 방식 수정

### DIFF
--- a/Cakey/Views/CakeyOrderForm/CakeOrderformView.swift
+++ b/Cakey/Views/CakeyOrderForm/CakeOrderformView.swift
@@ -35,6 +35,7 @@ struct CakeOrderformView: View {
             UIPageControl.appearance().currentPageIndicatorTintColor = UIColor.cakeyOrange1 // 현재 페이지 색상
             UIPageControl.appearance().pageIndicatorTintColor = UIColor.cakeyOrange3 // 나머지 페이지 색상
             viewModel.updateCakey()
+            print(viewModel.cakeyModel.cakeImages)
         }
         .navigationBarBackButtonHidden(true)
         .toolbarBackground(.cakeyYellow1, for: .navigationBar)
@@ -119,33 +120,35 @@ struct CakeOrderformView: View {
             .padding(.bottom, 28)
         
         // 키워드 리스트
-        VStack(alignment: .leading, spacing: 8) {
-            if viewModel.cakeyModel.cakeImages.first?.description == "" {
-                EmptyView()
-            } else {
-                ForEach(viewModel.cakeyModel.cakeImages.map { $0.description }, id: \.self) { keyword in
-                    HStack(spacing: 12) {
-                        Circle()
-                            .fill(.cakeyOrange1)
-                            .frame(width: 8, height: 8)
-                        
-                        Text("\(keyword)")
-                            .customStyledFont(font: .cakeyCallout, color: .cakeyOrange1)
-                            .frame(width: 235, alignment: .leading)
+        if viewModel.cakeyModel.cakeImages.first?.description == "" {
+            EmptyView()
+        } else {
+            VStack(alignment: .leading, spacing: 8) {
+                    ForEach(viewModel.cakeyModel.cakeImages.map { $0.description }, id: \.self) { keyword in
+                        if keyword != "" {
+                            HStack(spacing: 12) {
+                                Circle()
+                                    .fill(.cakeyOrange1)
+                                    .frame(width: 8, height: 8)
+                                
+                                Text("\(keyword)")
+                                    .customStyledFont(font: .cakeyCallout, color: .cakeyOrange1)
+                                    .frame(width: 235, alignment: .leading)
+                            }
+                        }
                     }
-                }
             }
-        }
-        .padding(.horizontal, 17)
-        .padding(.vertical, 18)
-        .background {
-            RoundedRectangle(cornerRadius: 40)
-                .strokeBorder(Color.cakeyOrange1, style: StrokeStyle(lineWidth: 3, lineCap: .round, lineJoin: .round, dash: [0.5, 7]))
-        }
-        .padding(8)
-        .background {
-            RoundedRectangle(cornerRadius: 45)
-                .stroke(Color.cakeyOrange1, lineWidth: 2)
+            .padding(.horizontal, 17)
+            .padding(.vertical, 18)
+            .background {
+                RoundedRectangle(cornerRadius: 40)
+                    .strokeBorder(Color.cakeyOrange1, style: StrokeStyle(lineWidth: 3, lineCap: .round, lineJoin: .round, dash: [0.5, 7]))
+            }
+            .padding(8)
+            .background {
+                RoundedRectangle(cornerRadius: 45)
+                    .stroke(Color.cakeyOrange1, lineWidth: 2)
+            }
         }
     }
     

--- a/Cakey/Views/CakeyOrderForm/CakeOrderformView.swift
+++ b/Cakey/Views/CakeyOrderForm/CakeOrderformView.swift
@@ -35,7 +35,6 @@ struct CakeOrderformView: View {
             UIPageControl.appearance().currentPageIndicatorTintColor = UIColor.cakeyOrange1 // 현재 페이지 색상
             UIPageControl.appearance().pageIndicatorTintColor = UIColor.cakeyOrange3 // 나머지 페이지 색상
             viewModel.updateCakey()
-            print(viewModel.cakeyModel.cakeImages)
         }
         .navigationBarBackButtonHidden(true)
         .toolbarBackground(.cakeyYellow1, for: .navigationBar)
@@ -120,8 +119,8 @@ struct CakeOrderformView: View {
             .padding(.bottom, 28)
         
         // 키워드 리스트
-        if viewModel.cakeyModel.cakeImages.first?.description == "" {
-            EmptyView()
+        if viewModel.cakeyModel.cakeImages.isEmpty {
+            
         } else {
             VStack(alignment: .leading, spacing: 8) {
                     ForEach(viewModel.cakeyModel.cakeImages.map { $0.description }, id: \.self) { keyword in

--- a/Cakey/Views/CakeyOrderForm/CakeOrderformView.swift
+++ b/Cakey/Views/CakeyOrderForm/CakeOrderformView.swift
@@ -120,15 +120,19 @@ struct CakeOrderformView: View {
         
         // 키워드 리스트
         VStack(alignment: .leading, spacing: 8) {
-            ForEach(viewModel.cakeyModel.cakeImages.map { $0.description }, id: \.self) { keyword in
-                HStack(spacing: 12) {
-                    Circle()
-                        .fill(.cakeyOrange1)
-                        .frame(width: 8, height: 8)
-                    
-                    Text("\(keyword)")
-                        .customStyledFont(font: .cakeyCallout, color: .cakeyOrange1)
-                        .frame(width: 235, alignment: .leading)
+            if viewModel.cakeyModel.cakeImages.first?.description == "" {
+                EmptyView()
+            } else {
+                ForEach(viewModel.cakeyModel.cakeImages.map { $0.description }, id: \.self) { keyword in
+                    HStack(spacing: 12) {
+                        Circle()
+                            .fill(.cakeyOrange1)
+                            .frame(width: 8, height: 8)
+                        
+                        Text("\(keyword)")
+                            .customStyledFont(font: .cakeyCallout, color: .cakeyOrange1)
+                            .frame(width: 235, alignment: .leading)
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
기존의 방식 수정
<!-- Close #{이슈 번호} -->

## 작업 내용
### 1. 저장된 Cakey모델에 cakeImages가 isEmpty이면 아무것도 뜨지 않도록 함

### 2. 기존에 키워드 갯수에 상관없이 6개의 점 리스트가 다 뜨던 것 수정
- 키워드 갯수만큼만 뜨도록

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
