### PR TITLE
[Feat] #83 CakeImageView 사진 누끼

### DIFF
--- a/Cakey/Model/Manager/ImagePicker.swift
+++ b/Cakey/Model/Manager/ImagePicker.swift
@@ -35,7 +35,9 @@ struct ImagePicker: UIViewControllerRepresentable {
 
         func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
             if let image = info[.originalImage] as? UIImage {
-                parent.onImagePicked(image)
+                // 이미지 방향을 수정
+                let fixedImage = fixImageOrientation(image)
+                parent.onImagePicked(fixedImage)
             } else {
                 parent.onImagePicked(nil)
             }
@@ -45,6 +47,18 @@ struct ImagePicker: UIViewControllerRepresentable {
         func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
             parent.onImagePicked(nil)
             picker.dismiss(animated: true)
+        }
+
+        /// 이미지의 방향을 표준화
+        private func fixImageOrientation(_ image: UIImage) -> UIImage {
+            guard image.imageOrientation != .up else { return image }
+
+            UIGraphicsBeginImageContextWithOptions(image.size, false, image.scale)
+            image.draw(in: CGRect(origin: .zero, size: image.size))
+            let normalizedImage = UIGraphicsGetImageFromCurrentImageContext()
+            UIGraphicsEndImageContext()
+            
+            return normalizedImage ?? image
         }
     }
 }

--- a/Cakey/Views/Components/DecoCarouselCell.swift
+++ b/Cakey/Views/Components/DecoCarouselCell.swift
@@ -29,11 +29,22 @@ struct DecoCarouselCell: View {
                             .overlay {
                                 if let image = decoImages[index].image {
                                     ZStack {
+                                        RoundedRectangle(cornerRadius: 12)
+                                            .fill(.cakeyYellow1)
+                                            .frame(width: 226, height: 226)
+                                        
                                         Image(uiImage: UIImage(data: image)!)
                                             .resizable()
                                             .scaledToFit()
                                             .frame(width: 226, height: 226)
                                             .clipShape(RoundedRectangle(cornerRadius: 12))
+                                        
+//                                        Image(uiImage: UIImage(data: image)!)
+//                                            .resizable()
+//                                            .scaledToFit()
+//                                            .frame(maxWidth: 226, maxHeight: 226)
+//                                            .padding(10)
+//                                            .clipShape(RoundedRectangle(cornerRadius: 12))
                                         
                                         RoundedRectangle(cornerRadius: 12)
                                             .fill(.clear)
@@ -186,11 +197,3 @@ struct DecoCarouselCell: View {
     }
 }
 
-//#Preview {
-//    ZStack {
-//        Color.cakeyYellow1
-//            .ignoresSafeArea(.all)
-//        
-//        DecoCarouselCell()
-//    }
-//}

--- a/Cakey/Views/Components/DecoCarouselCell.swift
+++ b/Cakey/Views/Components/DecoCarouselCell.swift
@@ -36,7 +36,7 @@ struct DecoCarouselCell: View {
                                         Image(uiImage: UIImage(data: image)!)
                                             .resizable()
                                             .scaledToFit()
-                                            .frame(width: 200, height: 200)
+                                            .frame(width: 230, height: 230)
                                             .clipShape(RoundedRectangle(cornerRadius: 12))
                                         
                                         RoundedRectangle(cornerRadius: 12)
@@ -147,7 +147,7 @@ struct DecoCarouselCell: View {
             let stickerImage = render(ciImage: outputImage)
             
             // 고정 크기로 리사이즈
-            let targetSize = CGSize(width: 200, height: 200)
+            let targetSize = CGSize(width: 230, height: 230)
             let resizedSticker = stickerImage.resize(to: targetSize)
             
             DispatchQueue.main.async {

--- a/Cakey/Views/Components/DecoCarouselCell.swift
+++ b/Cakey/Views/Components/DecoCarouselCell.swift
@@ -31,7 +31,7 @@ struct DecoCarouselCell: View {
                                     ZStack {
                                         Image(uiImage: UIImage(data: image)!)
                                             .resizable()
-                                            .scaledToFill()
+                                            .scaledToFit()
                                             .frame(width: 226, height: 226)
                                             .clipShape(RoundedRectangle(cornerRadius: 12))
                                         
@@ -97,17 +97,16 @@ struct DecoCarouselCell: View {
         .sheet(isPresented: $isAlbumPresented) {
             ImagePicker(sourceType: .photoLibrary) { selectedImage in
                 if let selectedImage = selectedImage {
-                    let targetSize = CGSize(width: 230, height: 230)
-                    
-                    // Downsample 이미지를 생성
-                    if let imageData = selectedImage.pngData(),
-                       let downsampledImage = ImageDownsample.downsample(data: imageData, to: targetSize),
-                       let uiImage = UIImage(data: downsampledImage.pngData()!) {
-                        
-                        // Downsample된 이미지를 스티커로 생성
-                        createSticker(for: uiImage) { stickerImage in
-                            if let stickerImage = stickerImage {
-                                decoImages[currentIndex].image = stickerImage.pngData()
+                    // 스티커 생성
+                    createSticker(for: selectedImage) { stickerImage in
+                        if let stickerImage = stickerImage {
+                            let targetSize = CGSize(width: 230, height: 230)
+                            
+                            // 스티커 이미지를 다운샘플링
+                            if let imageData = stickerImage.pngData(),
+                               let downsampledImage = ImageDownsample.downsample(data: imageData, to: targetSize) {
+                                // 다운샘플링된 이미지를 decoImages에 저장
+                                decoImages[currentIndex].image = downsampledImage.pngData()
                             }
                         }
                     }

--- a/Cakey/Views/Components/DecoCarouselCell.swift
+++ b/Cakey/Views/Components/DecoCarouselCell.swift
@@ -35,7 +35,6 @@ struct DecoCarouselCell: View {
                                             .frame(width: 226, height: 226)
                                             .clipShape(RoundedRectangle(cornerRadius: 12))
                                         
-                                        // TODO: - 테두리 이상한거 물어보기
                                         RoundedRectangle(cornerRadius: 12)
                                             .fill(.clear)
                                             .frame(width: 226, height: 226)

--- a/Cakey/Views/Components/DecoCarouselCell.swift
+++ b/Cakey/Views/Components/DecoCarouselCell.swift
@@ -36,15 +36,8 @@ struct DecoCarouselCell: View {
                                         Image(uiImage: UIImage(data: image)!)
                                             .resizable()
                                             .scaledToFit()
-                                            .frame(width: 226, height: 226)
+                                            .frame(width: 200, height: 200)
                                             .clipShape(RoundedRectangle(cornerRadius: 12))
-                                        
-//                                        Image(uiImage: UIImage(data: image)!)
-//                                            .resizable()
-//                                            .scaledToFit()
-//                                            .frame(maxWidth: 226, maxHeight: 226)
-//                                            .padding(10)
-//                                            .clipShape(RoundedRectangle(cornerRadius: 12))
                                         
                                         RoundedRectangle(cornerRadius: 12)
                                             .fill(.clear)
@@ -152,8 +145,13 @@ struct DecoCarouselCell: View {
             }
             let outputImage = apply(maskImage: maskImage, to: inputImage)
             let stickerImage = render(ciImage: outputImage)
+            
+            // 고정 크기로 리사이즈
+            let targetSize = CGSize(width: 200, height: 200)
+            let resizedSticker = stickerImage.resize(to: targetSize)
+            
             DispatchQueue.main.async {
-                completion(stickerImage)
+                completion(resizedSticker)
             }
         }
     }
@@ -197,3 +195,13 @@ struct DecoCarouselCell: View {
     }
 }
 
+
+// UIImage 크기 변경을 위한 유틸리티 함수
+private extension UIImage {
+    func resize(to targetSize: CGSize) -> UIImage? {
+        let renderer = UIGraphicsImageRenderer(size: targetSize)
+        return renderer.image { _ in
+            self.draw(in: CGRect(origin: .zero, size: targetSize))
+        }
+    }
+}


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
사진 등록 시 누끼 따지도록
<!-- Close #83  -->

## 작업 내용
### 1. 앨범에서 사진 가져올 때 이미지 누끼(스티커 처리)
- 티나가 사용했던 누끼 코드 가져와서 참고 및 약간의 변형 처리
- 다만, 사진의 누끼가 따지는 위치가 제각각 이다보니 피그마대로 정중앙에 배치하는 것이 어려워

## 비고 <!-- (Optional) -->
정 중앙 배치는... 추후 고려해 보는 것으로..

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
