### PR TITLE
[Feat] #73 CakeOrderformView 케이크만 저장하기 구현 및 모델에 사진 저장하기

### DIFF
--- a/Cakey/Extensions/UIView+Extensions.swift
+++ b/Cakey/Extensions/UIView+Extensions.swift
@@ -8,10 +8,20 @@
 import UIKit
 
 extension UIView {
+    // 스크린 화면 캡쳐 시 사용
     func captureAsImage() -> UIImage? {
         let renderer = UIGraphicsImageRenderer(size: self.bounds.size)
         return renderer.image { context in
             self.layer.render(in: context.cgContext)
         }
+    }
+    
+    // realm 저장소에 저장하기 위해 사용
+    func captureAsImageData() -> Data? {
+        let renderer = UIGraphicsImageRenderer(bounds: self.bounds)
+        let image = renderer.image { context in
+            self.layer.render(in: context.cgContext)
+        }
+        return image.pngData()
     }
 }

--- a/Cakey/Views/CakeyOrderForm/CakeOrderformView.swift
+++ b/Cakey/Views/CakeyOrderForm/CakeOrderformView.swift
@@ -33,6 +33,37 @@ struct CakeOrderformView: View {
         .onAppear {
             UIPageControl.appearance().currentPageIndicatorTintColor = UIColor.cakeyOrange1 // 현재 페이지 색상
             UIPageControl.appearance().pageIndicatorTintColor = UIColor.cakeyOrange3 // 나머지 페이지 색상
+            
+            // MARK: 뷰 캡쳐해서 모델에 저장하기
+            // Cake3DDecoView를 UIHostingController로 감싸기
+             let hostingController = UIHostingController(rootView: Cake3DDecoView(viewModel: viewModel))
+             let targetSize = CGSize(width: 300, height: 300) // 캡처 크기 설정
+             hostingController.view.frame = CGRect(origin: .zero, size: targetSize)
+             hostingController.view.backgroundColor = .clear // 배경 설정
+             
+             // UIWindow 가져오기
+             guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                   let window = windowScene.windows.first else {
+                 print("UIWindow를 가져오지 못했습니다.")
+                 return
+             }
+             window.addSubview(hostingController.view) // 캡처를 위해 화면에 추가
+
+             DispatchQueue.main.async {
+                 hostingController.view.layoutIfNeeded()
+                 
+                 // 캡처 수행
+                 if let imageData = hostingController.view.captureAsImageData() {
+                     viewModel.cakeyModel.cakeArImage = imageData // Data로 저장
+                     print("Cake3DDecoView 캡처 완료.")
+                 } else {
+                     print("이미지 데이터 캡처에 실패했습니다.")
+                 }
+                 
+                 // 뷰를 화면에서 제거
+                 hostingController.view.removeFromSuperview()
+             }
+            
             viewModel.updateCakey()
         }
         .navigationBarBackButtonHidden(true)
@@ -90,7 +121,36 @@ struct CakeOrderformView: View {
                  }
             }
             // TODO: 3D 케이크 자리
-            Button("케이크만 저장") { }
+            Button("케이크만 저장") {
+                // Cake3DDecoView를 UIHostingController로 감싸기
+                let hostingController = UIHostingController(rootView: Cake3DDecoView(viewModel: viewModel))
+                let targetSize = CGSize(width: 300, height: 300) // 캡처할 크기 지정
+                hostingController.view.frame = CGRect(origin: .zero, size: targetSize)
+                hostingController.view.backgroundColor = .clear // 배경 투명 설정
+
+                // 현재 UIWindow 가져오기
+                guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                      let window = windowScene.windows.first else {
+                    print("UIWindow를 가져오지 못했습니다.")
+                    return
+                }
+                window.addSubview(hostingController.view) // 화면에 추가 (캡처를 위해)
+
+                DispatchQueue.main.async {
+                    hostingController.view.layoutIfNeeded()
+                    
+                    // 캡처 수행
+                    if let capturedImage = hostingController.view.captureAsImage() {
+                        saveScreenShotToAlbum(capturedImage) // 캡처 이미지 앨범 저장
+                        print("Cake3DDecoView가 성공적으로 저장되었습니다.")
+                    } else {
+                        print("이미지 캡처에 실패했습니다.")
+                    }
+
+                    // 뷰를 화면에서 제거
+                    hostingController.view.removeFromSuperview()
+                }
+            }
         }
     }
     
@@ -104,7 +164,7 @@ struct CakeOrderformView: View {
     }
     
     @ViewBuilder
-    func cakeImage() -> some View {
+    func arCakeView() -> some View {
         Image(.zzamong)
             .resizable()
             .scaledToFit()
@@ -160,7 +220,7 @@ struct CakeOrderformView: View {
             .padding(.leading, 17)
             .padding(.bottom, 28)
             
-            cakeImage()
+            arCakeView()
                 .padding(.bottom, 16)
             
             designKeywordLists()

--- a/Cakey/Views/CakeyOrderForm/CakeOrderformView.swift
+++ b/Cakey/Views/CakeyOrderForm/CakeOrderformView.swift
@@ -123,11 +123,13 @@ struct CakeOrderformView: View {
             Button("케이크만 저장") {
                 // Cake3DDecoView를 UIHostingController로 감싸기
                 let hostingController = UIHostingController(rootView: arCakeView())
-                let targetSize = CGSize(width: 300, height: 300) // 캡처할 크기 지정
-                hostingController.view.frame = CGRect(origin: .zero, size: targetSize)
                 hostingController.view.backgroundColor = .clear // 배경 투명 설정
 
-                // 현재 UIWindow 가져오기
+                // 캡처할 뷰의 크기 설정
+                let fixedSize = CGSize(width: 300, height: 250) // arCakeView의 정해진 크기
+                hostingController.view.frame = CGRect(origin: .zero, size: fixedSize)
+
+                // UIWindow 가져오기
                 guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
                       let window = windowScene.windows.first else {
                     print("UIWindow를 가져오지 못했습니다.")
@@ -149,8 +151,6 @@ struct CakeOrderformView: View {
                     // 뷰를 화면에서 제거
                     hostingController.view.removeFromSuperview()
                 }
-                
-                print(viewModel.cakeyModel.cakeArImage ?? Data())
             }
         }
     }
@@ -168,8 +168,9 @@ struct CakeOrderformView: View {
     func arCakeView() -> some View {
         Image(.zzamong)
             .resizable()
-            .scaledToFit()
+            .scaledToFill()
             .frame(width: 300, height: 250)
+            .background(.clear)
     }
     
     @ViewBuilder

--- a/Cakey/Views/CakeyOrderForm/CakeOrderformView.swift
+++ b/Cakey/Views/CakeyOrderForm/CakeOrderformView.swift
@@ -36,7 +36,7 @@ struct CakeOrderformView: View {
             
             // MARK: 뷰 캡쳐해서 모델에 저장하기
             // Cake3DDecoView를 UIHostingController로 감싸기
-             let hostingController = UIHostingController(rootView: Cake3DDecoView(viewModel: viewModel))
+            let hostingController = UIHostingController(rootView: arCakeView())
              let targetSize = CGSize(width: 300, height: 300) // 캡처 크기 설정
              hostingController.view.frame = CGRect(origin: .zero, size: targetSize)
              hostingController.view.backgroundColor = .clear // 배경 설정
@@ -55,7 +55,7 @@ struct CakeOrderformView: View {
                  // 캡처 수행
                  if let imageData = hostingController.view.captureAsImageData() {
                      viewModel.cakeyModel.cakeArImage = imageData // Data로 저장
-                     print("Cake3DDecoView 캡처 완료.")
+                     print("캡처 완료.")
                  } else {
                      print("이미지 데이터 캡처에 실패했습니다.")
                  }
@@ -63,8 +63,6 @@ struct CakeOrderformView: View {
                  // 뷰를 화면에서 제거
                  hostingController.view.removeFromSuperview()
              }
-            
-            viewModel.updateCakey()
         }
         .navigationBarBackButtonHidden(true)
         .toolbarBackground(.cakeyYellow1, for: .navigationBar)
@@ -82,6 +80,7 @@ struct CakeOrderformView: View {
             
             ToolbarItem(placement: .topBarTrailing) {
                     Button {
+                        viewModel.updateCakey()
                         path.removeAll() // 홈으로 돌아가기
                     } label: {
                         Image(systemName: "house")
@@ -123,7 +122,7 @@ struct CakeOrderformView: View {
             // TODO: 3D 케이크 자리
             Button("케이크만 저장") {
                 // Cake3DDecoView를 UIHostingController로 감싸기
-                let hostingController = UIHostingController(rootView: Cake3DDecoView(viewModel: viewModel))
+                let hostingController = UIHostingController(rootView: arCakeView())
                 let targetSize = CGSize(width: 300, height: 300) // 캡처할 크기 지정
                 hostingController.view.frame = CGRect(origin: .zero, size: targetSize)
                 hostingController.view.backgroundColor = .clear // 배경 투명 설정
@@ -142,7 +141,7 @@ struct CakeOrderformView: View {
                     // 캡처 수행
                     if let capturedImage = hostingController.view.captureAsImage() {
                         saveScreenShotToAlbum(capturedImage) // 캡처 이미지 앨범 저장
-                        print("Cake3DDecoView가 성공적으로 저장되었습니다.")
+                        print("성공적으로 저장되었습니다.")
                     } else {
                         print("이미지 캡처에 실패했습니다.")
                     }
@@ -150,6 +149,8 @@ struct CakeOrderformView: View {
                     // 뷰를 화면에서 제거
                     hostingController.view.removeFromSuperview()
                 }
+                
+                print(viewModel.cakeyModel.cakeArImage ?? Data())
             }
         }
     }

--- a/Cakey/Views/Components/ArchieveCell.swift
+++ b/Cakey/Views/Components/ArchieveCell.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct ArchieveCell: View {
     var archieveDate: Date
+    var cakeImage: Data
     
     var body: some View {
         RoundedRectangle(cornerRadius: 12)
@@ -18,9 +19,16 @@ struct ArchieveCell: View {
             .overlay {
                 // TODO: 라미 3D 케이크 들어갈 자리(프레임 크기 알아서 변경 필요하면 해줘)
                 VStack(spacing: 20) {
-                    Rectangle()
-                        .fill(.pickerPink)
-                        .frame(width: 132, height: 110)
+                    if let image = UIImage(data: cakeImage) {
+                        Image(uiImage: image)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 132, height: 110)
+                    } else {
+                        Rectangle()
+                            .fill(.cakeyOrange3)
+                            .frame(width: 132, height: 110)
+                    }
                     
                     Text("\(archiveDateFormatter(from: archieveDate))")
                         .customStyledFont(font: .cakeySubhead, color: .cakeyOrange1)

--- a/Cakey/Views/Components/ArchieveCell.swift
+++ b/Cakey/Views/Components/ArchieveCell.swift
@@ -44,12 +44,3 @@ func archiveDateFormatter(from date: Date) -> String {
     return formatter.string(from: date)
 }
 
-
-//#Preview {
-//    ZStack {
-//        Color.cakeyYellow1
-//            .ignoresSafeArea(.all)
-//        
-//        ArchieveCell()
-//    }
-//}

--- a/Cakey/Views/OrderFormArchieve/ArchieveView.swift
+++ b/Cakey/Views/OrderFormArchieve/ArchieveView.swift
@@ -30,7 +30,7 @@ struct ArchieveView: View {
                 ScrollView {
                     LazyVGrid(columns: archieveColums, spacing: 16) {
                         ForEach(cakeyModelList.indices, id: \.self) { index in
-                            ArchieveCell(archieveDate: cakeyModelList[index].saveDate)
+                            ArchieveCell(archieveDate: cakeyModelList[index].saveDate, cakeImage: cakeyModelList[index].cakeArImage ?? Data())
                                 .onTapGesture {
                                     path.append(.archieveDetailView(cakeyModelList[index]))
                                 }


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
CakeOrderformView 케이크만 저장하기 구현 및 모델에 사진 저장하기
<!-- Close #73  -->

## 작업 내용
### 1. 케이크만 버튼 저장 시 이미지 저장시키기
- 다만 현재... 사이즈 이슈와 view가 실제로 캡쳐될지 확신이 없어서 조절은 최종 머지가 된 다음에 해야할 것 같음

### 2. 뷰 onAppear 될 때, 케이크 사진 캡쳐하기

### 3. 홈 버튼 누르면 저장소에 데이터 update 시키기
- 로직 한번 더 고민이 필요하고.. 이슈는 파놓음

### 4. ArchieveView에 cakeArImage 연결하기
- 로직대로 잘 저장되었는지 확인하기 위해서 아카이브 뷰에 연결해놓음!
- 저장된 사진이 없으면 rectangle 뜨도록 함

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
