### PR TITLE
[faet] #87 CakeLetteringView에서 스킵 눌러도 주문서 저장 되도록 수정

### DIFF
--- a/Cakey/Views/CakeyOrderForm/CakeLetteringView.swift
+++ b/Cakey/Views/CakeyOrderForm/CakeLetteringView.swift
@@ -81,6 +81,8 @@ struct CakeLetteringView: View {
                 Button {
                     viewModel.cakeyModel.letteringColor = "#000000" // default 검정색
                     viewModel.cakeyModel.letteringText = ""
+                    viewModel.cakeyModel.saveDate = .now
+                    viewModel.cakeyModel.isComplete = true
                     path.append(.cakeOrderformView)
                 } label: {
                     Text("SKIP")


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
CakeLetteringView에서 스킵 눌러도 주문서 저장 되도록 수정
<!-- Close #87 -->

## 작업 내용
### 1. skip 버튼에 기능 추가하기
- saveDate, isComplete 저장시키기

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
