### PR TITLE
[Chore] #108 ArchieveDetailView 케이크만 저장 로직 수정

### DIFF
--- a/Cakey.xcodeproj/xcuserdata/leewonsun.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Cakey.xcodeproj/xcuserdata/leewonsun.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>Cakey.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 	</dict>
 </dict>

--- a/Cakey/CakeScene/.swiftpm/xcode/xcuserdata/leewonsun.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Cakey/CakeScene/.swiftpm/xcode/xcuserdata/leewonsun.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>CakeScene.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>2</integer>
+			<integer>1</integer>
 		</dict>
 	</dict>
 </dict>

--- a/Cakey/composer/.swiftpm/xcode/xcuserdata/leewonsun.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Cakey/composer/.swiftpm/xcode/xcuserdata/leewonsun.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>composer.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>2</integer>
 		</dict>
 	</dict>
 </dict>


### PR DESCRIPTION
<!-- ## 제목 양식
> [카테고리] #{이슈 번호} {PR 내용}
-->
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
ArchieveDetailView 케이크만 저장 로직 수정
<!-- Close #108 -->

## 작업 내용
### 1. 기존 3DFinalView 연결되던 것 저장된 사진으로 띄우기 변경
- 아직 완전하진 않지만, 우선 작동하여 진행하는 것으로

## 비고 <!-- (Optional) -->

### 작업 스크린샷 <!-- (Optional) -->
![IMG_3552](https://github.com/user-attachments/assets/f24a56e8-79af-4bee-ac08-b11ac801e285)

### 리뷰어에게 남길 말 <!-- (Optional) -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
